### PR TITLE
fix table id for datatable

### DIFF
--- a/data.md
+++ b/data.md
@@ -5,12 +5,12 @@ permalink: /data/
 ---
 {% assign items = site.data[site.csvtitle] %}
 {% include datadownload.html %}
-<!-- currently downloaded version of datatables is bundled with bootstrap and responsive and csv download extensions -->
+
 <style>.description{min-width:400px;"}</style>
 ## Collection Data 
 
 The table below provides sorting and basic search of the archive contents. Use the download button at the top right to download the entire metadata spreadsheet building the collection. Use the "CSV" button below to download the metadata you see on the page.  
-<table id="item-table table-striped">
+<table id="item-table" class="table table-striped">
     <thead>
         <tr>
         {% assign tableheaders = site.datatable | split:',' %}


### PR DESCRIPTION
you added a class to the table `id`, thus the id wasn't working, datatables couldnt find it.

also, you should just delete out that whole directory of datatables junk and start fresh.